### PR TITLE
minor adjustments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea
+.vscode
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This action assumes you use [poetry](https://python-poetry.org/) as your package
 **This action is also supported on private GitHub actions runners**. If you do not use a custom runner, you may use the builtin functionality `GITHUB_TOKEN` with write permissions as the `ACCESS_TOKEN` as seen in the first example. See [https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow)
 
 
-> :warning: We recommend you to use this workflow with the test pypi registry e.g. `REGISTRY: "https://test.pypi.org/simple/"` until you can confirm your workflow works as expected.
+> :warning: We recommend you to use this workflow with the test PyPI registry e.g. `REGISTRY: "https://test.pypi.org/simple/"` until you can confirm your workflow works as expected.
 
 ## Process
 
@@ -36,7 +36,7 @@ Each example requires you to:
 1. Create a workflow file e.g. `.github/workflows/publish.yml`
 2. Create a new release and tag e.g. `1.0.0` and the action will be triggered and publishes your package
 
-### publish.yaml to publish to public pypi
+### publish.yaml to publish to public PyPI
 
 - Requires GitHub secrets:
 	- `PYPI_PASSWORD` with a valid token
@@ -65,7 +65,7 @@ jobs:
           PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
 ```
 
-### publish.yaml to publish to the test pypi
+### publish.yaml to publish to the test PyPI
 
 - Requires GitHub secrets:
 	- `PYPI_PASSWORD` with a valid token
@@ -92,10 +92,10 @@ jobs:
           REGISTRY: "https://test.pypi.org/legacy/"
 ```
 
-### publish.yaml to publish to a private pypi
+### publish.yaml to publish to a private PyPI
 
 - Requires GitHub secrets:
-	- `PYPI_USER` username for the pypi registry
+	- `PYPI_USER` username for the PyPI registry
 	- `PYPI_PASSWORD` with the password for the `PYPI_USER` user
 	- `ACCESS_TOKEN` access token with write access to the GitHub repository
 
@@ -110,7 +110,7 @@ jobs:
   publish-service-client-package:
     runs-on: ubuntu-latest
     steps:
-      - name: Publish PyPi package
+      - name: Publish PyPI package
         uses: code-specialist/pypi-poetry-publish@v1
         with:
           PACKAGE_DIRECTORY: "./example-package/"

--- a/action.yaml
+++ b/action.yaml
@@ -1,4 +1,4 @@
-name: 'PyPi Poetry Publish'
+name: 'PyPI Poetry Publish'
 description: 'Opinionated GitHub action to fully automate publishing packages to any PyPI registry - using Poetry and GitHub releases'
 branding:
   icon: 'package'
@@ -16,7 +16,7 @@ inputs:
     required: false
     default: '3.10'
   PYPI_PASSWORD:
-    description: 'Password for the user to publish to PyPi. May also be a Token - requires the `PYPI_USERNAME` to be `__token__`'
+    description: 'Password for the user to publish to PyPI. May also be a Token - requires the `PYPI_USERNAME` to be `__token__`'
     required: true
   PYPI_USERNAME:
     description: 'The username for the registry. Defaults to __token__'
@@ -60,7 +60,7 @@ runs:
     - name: Add and Commit Version
       run: |
         git add ${{ inputs.PACKAGE_DIRECTORY }}__init__.py ./pyproject.toml
-        git config --global user.name "PyPi Poetry Publish Bot"
+        git config --global user.name "PyPI Poetry Publish Bot"
         git config --global user.email "admin@code-specialist.com"
         git commit -m "Change version to ${{ github.event.release.tag_name }}" --allow-empty
         git push origin HEAD:${{ inputs.BRANCH }}


### PR DESCRIPTION
Looks great, thx 👍 I have just some really small suggestions, so that the "PyPI" name is consistently spelled correctly.

The only additional thing I could imagine to be nice is to include something like this for the required project setup:

```
my-project/
    my-project/
        __init__.py
    pyproject.toml
```

and also an explicit example of the `__init__.py`, e.g.

```python
__version__='1.0.0'
```

However, I couldn't think of a nice way to add this to the readme so far, that's why I didn't include it in this pr